### PR TITLE
chore: upgrade to Calcit 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cirru_edn"
-version = "0.7.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d054d1542ed06c390236ac86d7f318c0149f531978386cb6de74df47eda32f21"
+checksum = "7f9a574a5164698fdd0881368444c47fad4b3188f82898386b9f28b83d9626d7"
 dependencies = [
  "cirru_parser",
  "cjk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ crate-type = ["dylib"] # Creates dynamic lib
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cirru_edn = "0.7.9"
+cirru_edn = "0.8.0"
 simple-websockets = "0.1.6"

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,79 +1,91 @@
 
-{} (:about "|file is generated - never edit directly; learn cr edit/tree workflows before changing") (:package |wss)
-  :configs $ {} (:init-fn |wss.test/main!) (:reload-fn |wss.test/reload!) (:version |0.2.7)
-    :modules $ []
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |wss) (:version |0.2.7)
   :entries $ {}
-    :demo $ {} (:init-fn |wss.test/demo!) (:reload-fn |wss.test/reload!) (:version |0.0.0)
+    :default $ {} (:description |) (:init-fn 'wss.test/main!) (:mode :native) (:reload-fn 'wss.test/reload!)
       :modules $ []
+      :type-slots $ {}
+    :demo $ {} (:description |) (:init-fn 'wss.test/demo!) (:mode :native) (:reload-fn 'wss.test/reload!)
+      :modules $ []
+      :type-slots $ {}
   :files $ {}
-    |wss.core $ %{} :FileEntry
+    |wss.core $ %{} 'FileEntry
       :defs $ {}
-        |wss-each! $ %{} :CodeEntry (:doc "|Iterate over connected clients. Args: callback (fn (client-id)). Example: (wss-each! (fn (id) (wss-send! id \"Hello!\")))") (:schema nil)
+        |wss-each! $ %{} 'CodeEntry (:doc "|Iterate over connected clients. Args: callback (fn (client-id)). Example: (wss-each! (fn (id) (wss-send! id \"Hello!\")))")
           :code $ quote
             defn wss-each! (cb)
-              &call-dylib-edn-fn (get-dylib-path "\"/dylibs/libcalcit_wss") "\"wss_each" cb
+              &call-dylib-edn-fn (get-dylib-path |/dylibs/libcalcit_wss) |wss_each cb
           :examples $ []
-        |wss-send! $ %{} :CodeEntry (:doc "|Send a message to a WebSocket client. Args: id (string/number), message (any). Example: (wss-send! 123 \"Hello!\")") (:schema nil)
+          :schema $ :: 'Dynamic
+        |wss-send! $ %{} 'CodeEntry (:doc "|Send a message to a WebSocket client. Args: id (string/number), message (any). Example: (wss-send! 123 \"Hello!\")")
           :code $ quote
             defn wss-send! (client message)
-              &call-dylib-edn (get-dylib-path "\"/dylibs/libcalcit_wss") "\"wss_send" client message
+              &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_wss) |wss_send client message
           :examples $ []
-        |wss-serve! $ %{} :CodeEntry (:doc "|Start a WebSocket server. Args: options (map), callback function (fn (income-data)). Example: (wss-serve! {:port 9001} (fn (income) (println income)))") (:schema nil)
+          :schema $ :: 'Dynamic
+        |wss-serve! $ %{} 'CodeEntry (:doc "|Start a WebSocket server. Args: options (map), callback function (fn (income-data)). Example: (wss-serve! {:port 9001} (fn (income) (println income)))")
           :code $ quote
             defn wss-serve! (options cb)
-              &call-dylib-edn-fn (get-dylib-path "\"/dylibs/libcalcit_wss") "\"wss_serve" options cb
+              &call-dylib-edn-fn (get-dylib-path |/dylibs/libcalcit_wss) |wss_serve options cb
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns wss.core $ :require
             wss.$meta :refer $ calcit-dirname
             wss.util :refer $ get-dylib-path
-    |wss.test $ %{} :FileEntry
+    |wss.test $ %{} 'FileEntry
       :defs $ {}
-        |demo! $ %{} :CodeEntry (:doc |) (:schema nil)
+        |demo! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn demo! ()
               wss-serve!
                 {} $ :port 9001
                 fn (income) (println income)
                   wss-each! $ fn (id)
-                    wss-send! id $ str "\"hello from: " income
-              println "\"demo started"
+                    wss-send! id $ str "|hello from: " income
+              println "|demo started"
           :examples $ []
-        |main! $ %{} :CodeEntry (:doc |) (:schema nil)
+          :schema $ :: 'Dynamic
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () $ run-tests
           :examples $ []
-        |reload! $ %{} :CodeEntry (:doc |) (:schema nil)
+          :schema $ :: 'Dynamic
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            defn reload! () $ println "\"did nothing on reload"
+            defn reload! () $ println "|did nothing on reload"
           :examples $ []
-        |run-tests $ %{} :CodeEntry (:doc |) (:schema nil)
+          :schema $ :: 'Dynamic
+        |run-tests $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            defn run-tests () (println "\"%%%% test for lib") (println calcit-filename calcit-dirname)
+            defn run-tests () (println "|%%%% test for lib") (println calcit-filename calcit-dirname)
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns wss.test $ :require
             wss.core :refer $ wss-serve! wss-each! wss-send!
             wss.$meta :refer $ calcit-dirname calcit-filename
-    |wss.util $ %{} :FileEntry
+    |wss.util $ %{} 'FileEntry
       :defs $ {}
-        |get-dylib-ext $ %{} :CodeEntry (:doc |) (:schema nil)
+        |get-dylib-ext $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            defmacro get-dylib-ext () $ case-default (&get-os) "\".so" (:macos "\".dylib") (:windows "\".dll")
+            defmacro get-dylib-ext () $ case-default (&get-os) |.so (:macos |.dylib) (:windows |.dll)
           :examples $ []
-        |get-dylib-path $ %{} :CodeEntry (:doc |) (:schema nil)
+          :schema $ :: 'Dynamic
+        |get-dylib-path $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn get-dylib-path (p)
               str (or-current-path calcit-dirname) p $ get-dylib-ext
           :examples $ []
-        |or-current-path $ %{} :CodeEntry (:doc |) (:schema nil)
+          :schema $ :: 'Dynamic
+        |or-current-path $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn or-current-path (p)
-              if (blank? p) "\"." p
+              if (blank? p) |. p
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns wss.util $ :require
             wss.$meta :refer $ calcit-dirname calcit-filename

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,3 +1,3 @@
 
-{}
-  :calcit-version |0.12.35
+{} (:calcit-version |0.13.7)
+  :dependencies $ {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use cirru_edn::{Edn, EdnTupleView};
+use cirru_edn::Edn;
 use simple_websockets::{Event, Message, Responder};
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, RwLock};
@@ -46,11 +46,7 @@ pub fn wss_serve(
             let mut clients = CLIENTS.write().unwrap();
             clients.insert(client_id, responder);
           }
-          if let Err(e) = handler(vec![Edn::Tuple(EdnTupleView {
-            enum_tag: None,
-            tag: Arc::new(Edn::tag("connect")),
-            extra: vec![Edn::Number(client_id as f64)],
-          })]) {
+          if let Err(e) = handler(vec![Edn::enum_value("connect", vec![Edn::Number(client_id as f64)])]) {
             println!("Failed to handle connect: {}", e)
           }
         }
@@ -60,30 +56,21 @@ pub fn wss_serve(
             let mut clients = CLIENTS.write().unwrap();
             clients.remove(&client_id);
           }
-          if let Err(e) = handler(vec![Edn::Tuple(EdnTupleView {
-            enum_tag: None,
-            tag: Arc::new(Edn::tag("disconnect")),
-            extra: vec![Edn::Number(client_id as f64)],
-          })]) {
+          if let Err(e) = handler(vec![Edn::enum_value("disconnect", vec![Edn::Number(client_id as f64)])]) {
             println!("Failed to handle disconnect: {}", e)
           }
         }
         Event::Message(client_id, message) => match message {
           Message::Text(s) => {
-            if let Err(e) = handler(vec![Edn::Tuple(EdnTupleView {
-              enum_tag: None,
-              tag: Arc::new(Edn::tag("message")),
-              extra: vec![Edn::Number(client_id as f64), Edn::Str(s.into())],
-            })]) {
+            if let Err(e) = handler(vec![Edn::enum_value(
+              "message",
+              vec![Edn::Number(client_id as f64), Edn::Str(s.into())],
+            )]) {
               println!("Failed to handle text message: {}", e)
             }
           }
           Message::Binary(buf) => {
-            if let Err(e) = handler(vec![Edn::Tuple(EdnTupleView {
-              enum_tag: None,
-              tag: Arc::new(Edn::tag("blob")),
-              extra: vec![Edn::Number(client_id as f64), Edn::Buffer(buf)],
-            })]) {
+            if let Err(e) = handler(vec![Edn::enum_value("blob", vec![Edn::Number(client_id as f64), Edn::Buffer(buf)])]) {
               println!("Failed to handle binary message: {}", e)
             }
           }


### PR DESCRIPTION
## Summary
- upgrade Calcit and Cirru EDN native ABI dependencies
- migrate websocket event construction from Tuple to Enum
- canonicalize the Snapshot for the current project configuration

## Validation
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo build --release`
- `cr --check-only`
- `cr`