### PR TITLE
chore: upgrade Calcit to 0.13.13

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: calcit-lang/setup-cr@0.0.8
+      - uses: calcit-lang/setup-cr@0.0.9
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,3 +1,3 @@
 
-{} (:calcit-version |0.13.7)
+{} (:calcit-version |0.13.13)
   :dependencies $ {}

--- a/editing-history/202608130014-upgrade-calcit-0.13.13.md
+++ b/editing-history/202608130014-upgrade-calcit-0.13.13.md
@@ -1,0 +1,4 @@
+# upgrade Calcit 0.13.13
+
+- Updated CI to `calcit-lang/setup-cr@0.0.9` and recorded Calcit `0.13.13` in `deps.cirru`.
+- Verified `caps --ci` installs the project-scoped dependency view and `cr` compiles successfully.


### PR DESCRIPTION
Updates CI to setup-cr 0.0.9 and records Calcit 0.13.13 in deps.cirru.\n\nValidated with `caps --ci` and `cr` using the new project-scoped module view.