### PR TITLE
chore: upgrade calcit to 0.13.19

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,3 +1,3 @@
 
-{} (:calcit-version |0.13.15)
+{} (:calcit-version |0.13.19)
   :dependencies $ {}


### PR DESCRIPTION
Per `cr docs read upgrade`:
- `caps upgrade --all`: `:calcit-version` -> 0.13.19; pinned deps bumped to latest tags
- `@calcit/procs` synced to ^0.13.19 in package.json / yarn.lock
- modules re-synced via `caps`

deps.cirru audit: all deps pinned to versions; no :dev-dependencies section.