### PR TITLE
chore: upgrade Calcit to 0.13.27

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,10 +1,12 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |wss) (:version |0.2.12)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |wss)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'wss.test/main!) (:mode :native) (:reload-fn 'wss.test/reload!)
+      :feature-policy $ {}
       :modules $ []
       :type-slots $ {}
     :demo $ {} (:description |) (:init-fn 'wss.test/demo!) (:mode :native) (:reload-fn 'wss.test/reload!)
+      :feature-policy $ {}
       :modules $ []
       :type-slots $ {}
   :files $ {}

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,3 +1,3 @@
 
-{} (:calcit-version |0.13.15)
+{} (:calcit-version |0.13.27)
   :dependencies $ {}


### PR DESCRIPTION
本地已使用 Calcit 0.13.27 执行 `cr --check-only` 验证通过。

请等待 Actions 全部通过后再合并。此 PR 不应自动合并。