### PR TITLE
fix: complete Calcit CLI migration

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: calcit-lang/setup-calcit@6a2e53ae41e4f0d5856a424b9ed4470d90ea6876
+      - uses: calcit-lang/setup-calcit@3b5843cb725963bb4ee158cfe49dad877134963e
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: calcit-lang/setup-calcit@v1
+      - uses: calcit-lang/setup-calcit@6a2e53ae41e4f0d5856a424b9ed4470d90ea6876
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -25,4 +25,4 @@ jobs:
 
       - run: mkdir dylibs/ && ls target/release/ && cp -v target/release/*.* dylibs/
 
-      - run: cr
+      - run: calcit calcit.cirru

--- a/history/2026082220-upgrade-calcit-01329.md
+++ b/history/2026082220-upgrade-calcit-01329.md
@@ -1,5 +1,5 @@
 2026-08-22 20:00 — Upgrade calcit-wss toolchain
 
 - Updated the Calcit version to 0.13.29 after syncing main.
-- Replaced the remaining `cr` commands in project guidance with `calcit`.
+- Replaced the remaining `cr` commands in project guidance and CI with `calcit`.
 - Verified snapshot formatting, check-only, and JS generation.

--- a/history/2026082300-fix-calcit-workflow.md
+++ b/history/2026082300-fix-calcit-workflow.md
@@ -1,0 +1,4 @@
+# 2026-08-23 00:00 Fix Calcit workflow command
+
+- 将 check workflow 中遗留的 `cr` 默认入口改为 `calcit calcit.cirru`。
+- 固定 setup-calcit action 到已验证的 commit SHA。


### PR DESCRIPTION
Follow-up to the merged Calcit 0.13.29 upgrade. Replace remaining cr commands with calcit, pin setup-calcit to an immutable SHA, and keep calcit.cirru guidance current. Verified with calcit 0.13.29 and check-only.