### PR TITLE
chore: upgrade calcit-wss to Calcit 0.13.31

### DIFF
--- a/2026082222-upgrade-calcit-01331.md
+++ b/2026082222-upgrade-calcit-01331.md
@@ -1,0 +1,4 @@
+# Upgrade Calcit to 0.13.31
+
+- Updated the fixture/runtime Calcit version to 0.13.31.
+- Bumped calcit-wss to 0.2.13 for a stable tag.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit_wss"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "cirru_edn",
  "simple-websockets",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_wss"
-version = "0.2.12"
+version = "0.2.13"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,3 +1,3 @@
 
-{} (:calcit-version |0.13.29)
+{} (:version |0.2.13) (:calcit-version |0.13.31)
   :dependencies $ {}


### PR DESCRIPTION
Upgrade calcit-wss fixture/runtime and release 0.2.13.\n\nActions must pass and all review comments must be resolved before merge.