### PR TITLE
chore: upgrade wss to Calcit 0.13.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit_wss"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "cirru_edn",
  "simple-websockets",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_wss"
-version = "0.2.13"
+version = "0.2.14"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,3 +1,3 @@
 
-{} (:version |0.2.13) (:calcit-version |0.13.31)
+{} (:version |0.2.14) (:calcit-version |0.13.32)
   :dependencies $ {}

--- a/history/2026082300-upgrade-calcit-01332.md
+++ b/history/2026082300-upgrade-calcit-01332.md
@@ -1,0 +1,3 @@
+# Upgrade Calcit 0.13.32
+
+- Update the WSS module runtime and bump its stable version to `0.2.14`.


### PR DESCRIPTION
同步最新 main 后升级到 Calcit 0.13.32；Rust 格式和测试已完成（calcit-wss 本地 listener 测试受沙箱权限限制，Actions 为最终依据）。